### PR TITLE
Use references to identify channels.  Copy ElixirALE interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,36 +68,36 @@ Here's a simple example of using it.
 ```Elixir
 # On the Raspberry Pi, the IO expander is connected to I2C bus 1 (i2c-1).
 # Its 7-bit address is 0x20. (see datasheet)
-iex> {:ok, fd} = ElixirCircuits.I2C.open("i2c-1")
-{:ok, 34}
+iex> {:ok, ref} = ElixirCircuits.I2C.open("i2c-1", 0x20)
+{:ok, #Reference<0.1994877202.537788433.199599>}
 
 # By default, all 8 GPIOs are set to inputs. Set the 4 high bits to outputs
 # so that we can toggle the LEDs. (Write 0x0f to register 0x00)
-iex> ElixirCircuits.I2C.write(fd, 0x20, <<0x00, 0x0f>>)
+iex> ElixirCircuits.I2C.write(ref, <<0x00, 0x0f>>)
 :ok
 
 # Turn on the LED attached to bit 4 on the expander. (Write 0x10 to register
 # 0x09)
-iex> ElixirCircuits.I2C.write(fd, 0x20, <<0x09, 0x10>>)
+iex> ElixirCircuits.I2C.write(ref, <<0x09, 0x10>>)
 :ok
 
 # Read all 11 of the expander's registers to see that the bit 0 switch is
 # the only one on and that the bit 4 LED is on.
-iex> ElixirCircuits.I2C.write(fd, 0x20, <<0>>)  # Set the next register to be read to 0
+iex> ElixirCircuits.I2C.write(ref, <<0>>)  # Set the next register to be read to 0
 :ok
 
-iex> ElixirCircuits.I2C.read(fd, 0x20, 11)
-{:ok, <<15, 0, 0, 0, 0, 0, 0, 0, 0, 17, 16>>}
+iex> ElixirCircuits.I2C.read(ref, 11)
+<<15, 0, 0, 0, 0, 0, 0, 0, 0, 17, 16>>
 
 # The operation of writing one or more bytes to select a register and
 # then reading is very common, so a shortcut is to just run the following:
-iex> ElixirCircuits.I2C.write_read(fd, 0x20, <<0>>, 11)
-{:ok, <<15, 0, 0, 0, 0, 0, 0, 0, 0, 17, 16>>}
+iex> ElixirCircuits.I2C.write_read(ref, <<0>>, 11)
+<<15, 0, 0, 0, 0, 0, 0, 0, 0, 17, 16>>
 
 # The 17 in register 9 says that bits 0 and bit 4 are high
 # We could have just read register 9.
 
-iex> ElixirCircuits.I2C.write_read(fd, 0x20, <<9>>, 1)
+iex> ElixirCircuits.I2C.write_read(ref, <<9>>, 1)
 {:ok, <<17>>}
 ```
 

--- a/lib/i2c.ex
+++ b/lib/i2c.ex
@@ -4,7 +4,7 @@ defmodule ElixirCircuits.I2C do
   buses on Linux platforms. Internally, it uses the Linux
   sysclass interface so that it does not require platform-dependent code.
   """
-  alias ElixirCircuits.I2C.Nif, as: Nif
+  alias ElixirCircuits.I2C.Nif
 
   # Public API
 
@@ -12,38 +12,73 @@ defmodule ElixirCircuits.I2C do
 
   @doc """
   Open the I2C device (Example:"i2c-1")
-  On success, returns an integer file descriptor.
-  Use file descriptor (fd) in subsequent calls to read/write I2C nodes
+  Address is the default I2C device slave address
+  On success, returns a reference to the I2C bus resource.
+  Use the reference in subsequent calls to read/write I2C device
   """
-  @spec open(binary) :: {:ok, integer} | {:error, term}
-  def open(device) do
-    Nif.open(to_charlist(device))
+  @spec open(binary, i2c_address) :: {:ok, reference()} | {:error, term}
+  def open(device, address) do
+    Nif.open(to_charlist(device), address)
+  end
+
+  @doc """
+  Initiate a read transaction to the device
+  and specified number of bytes to read
+  """
+  @spec read(reference(), integer) :: binary | {:error, term}
+  def read(ref, count) do
+    Nif.read(ref, count)
   end
 
   @doc """
   Initiate a read transaction to the device at the specified `address`
   and specified number of bytes to read
   """
-  @spec read(integer, i2c_address, integer) :: {:ok, binary} | {:error, term}
-  def read(fd, address, count) do
-    Nif.read(fd, address, count)
+  @spec read_device(reference(), i2c_address, integer) :: binary | {:error, term}
+  def read_device(ref, address, count) do
+    Nif.read_device(ref, address, count)
+  end
+
+  @doc """
+  Write the specified `data` to the device
+  """
+  @spec write(reference(), binary) :: :ok | {:error, term}
+  def write(ref, data) do
+    Nif.write(ref, data)
   end
 
   @doc """
   Write the specified `data` to the device at `address`.
   """
-  @spec write(integer, i2c_address, binary) :: :ok | {:error, term}
-  def write(fd, address, data) do
-    Nif.write(fd, address, data)
+  @spec write_device(reference(), i2c_address, binary) :: :ok | {:error, term}
+  def write_device(ref, address, data) do
+    Nif.write_device(ref, address, data)
   end
 
   @doc """
-  Write the specified `data` to the device at 'address' 
-  and then read the specified number of bytes. 
+  Write the specified `data` to the device
+  and then read the specified number of bytes.
   """
-  @spec write_read(integer, i2c_address, binary, integer) :: {:ok, binary} | {:error, term}
-  def write_read(fd, address, write_data, read_count) do
-    Nif.write_read(fd, address, write_data, read_count)
+  @spec write_read(reference(), binary, integer) :: binary | {:error, term}
+  def write_read(ref, write_data, read_count) do
+    Nif.write_read(ref, write_data, read_count)
+  end
+
+  @doc """
+  Write the specified `data` to the device at 'address'
+  and then read the specified number of bytes.
+  """
+  @spec write_read_device(reference(), i2c_address, binary, integer) :: binary | {:error, term}
+  def write_read_device(ref, address, write_data, read_count) do
+    Nif.write_read_device(ref, address, write_data, read_count)
+  end
+
+  @doc """
+  close the I2C device
+  """
+  @spec close(reference()) :: :ok
+  def close(ref) do
+    Nif.close(ref)
   end
 
   @doc """
@@ -69,8 +104,7 @@ defmodule ElixirCircuits.I2C do
 
   WARNING: This is intended to be a debugging aid. Reading bytes from devices
   can advance internal state machines and might cause them to get out of sync
-  with other code. Also the I2C device file is (re)opened, 
-  which generates a new file descriptor, which will invalidate an existing 'fd'.
+  with other code.
 
   ```
   iex> ElxirCircuits.I2C.detect_devices("i2c-1")
@@ -80,12 +114,21 @@ defmodule ElixirCircuits.I2C do
   specified I2C bus. If you get back `'Hh'` or other letters, then IEx
   converted the list to an Erlang string. Run `i v()` to get information about
   the return value and look at the raw string representation for addresses.
+
+  If you already have a reference to an open device, then you may
+  pass its `reference` to `detect_devices/1` instead.
   """
-  @spec detect_devices(binary) :: [integer] | {:error, term}
-  def detect_devices(devname) do
-    case open(devname) do
-      {:ok, fd} ->
-        Enum.reject(0..127, &(read(fd, &1, 1) == {:error, :read_failed}))
+  @spec detect_devices(reference() | binary) :: [integer] | {:error, term}
+  def detect_devices(ref) when is_reference(ref) do
+    Enum.reject(0..127, &(read_device(ref, &1, 1) == {:error, :read_failed}))
+  end
+
+  def detect_devices(devname) when is_binary(devname) do
+    case open(devname, 0) do
+      {:ok, ref} ->
+        devices = detect_devices(ref)
+        close(ref)
+        devices
 
       error ->
         error

--- a/lib/i2c/i2c_nif.ex
+++ b/lib/i2c/i2c_nif.ex
@@ -7,23 +7,46 @@ defmodule ElixirCircuits.I2C.Nif do
   """
 
   def load_nif() do
-    nif_exec = '#{:code.priv_dir(:i2c)}/i2c_nif'
-    :erlang.load_nif(nif_exec, 0)
+    nif_binary = Application.app_dir(:i2c, "priv/i2c_nif")
+
+    case :erlang.load_nif(to_charlist(nif_binary), 0) do
+      {:error, reason} ->
+        IO.puts("Error: " <> to_string(reason) <> " Loading: " <> nif_binary)
+
+      _ ->
+        :ok
+    end
   end
 
-  def open(_device) do
+  def open(_device, _address) do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def read(_fd, _address, _count) do
+  def read(_ref, _count) do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def write(_fd, _address, _data) do
+  def read_device(_ref, _address, _count) do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def write_read(_fd, _address, _write_data, _read_count) do
+  def write(_ref, _data) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def write_device(_ref, _address, _data) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def write_read(_ref, _write_data, _read_count) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def write_read_device(_ref, _address, _write_data, _read_count) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  def close(_ref) do
     :erlang.nif_error(:nif_not_loaded)
   end
 end

--- a/src/i2c_nif.c
+++ b/src/i2c_nif.c
@@ -16,28 +16,8 @@
  * I2C NIF implementation.
  */
 
-#include <err.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/ioctl.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#include "i2c_nif.h"
 
-#include "linux/i2c-dev.h"
-#include "erl_nif.h"
-
-//#define DEBUG
-#ifdef DEBUG
-#define debug(...) do { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\r\n"); } while(0)
-#else
-#define debug(...)
-#endif
-
-#define I2C_BUFFER_MAX 8192
 
 /**
  * @brief   I2C combined write/read operation
@@ -91,35 +71,131 @@ static int i2c_transfer(int fd,
 }
 
 
-static ERL_NIF_TERM open_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+static int i2c_load(ErlNifEnv *env, void **priv_data, ERL_NIF_TERM info)
 {
-    char device[32];
-    char devpath[64]="/dev/";
+#ifdef DEBUG
+#ifdef LOG_PATH
+    log_location = fopen(LOG_PATH, "w");
+#endif
+#endif
+    debug("i2c_load");
 
-    if (!enif_get_string(env, argv[0], (char*)&device, sizeof(device), ERL_NIF_LATIN1))
-        return enif_make_badarg(env);
+    I2cNifPriv *priv = enif_alloc(sizeof(I2cNifPriv));
+    if (!priv) {
+        error("Can't allocate i2c priv");
+        return 1;
+    }
 
-    strncat(devpath, device, sizeof(device));
+    priv->i2c_nif_res_type = enif_open_resource_type(env, NULL, "i2c_nif_res_type", NULL, ERL_NIF_RT_CREATE, NULL);
+    if (priv->i2c_nif_res_type == NULL) {
+        error("open I2C NIF resource type failed");
+        return 1;
+    }
 
-    int fd = open(devpath, O_RDWR);
-    if (fd < 0)
-        return enif_make_tuple2(env, enif_make_atom(env, "error"),
-                                enif_make_atom(env, "access_denied"));
+    priv->i2c_nif_res_list = NULL;
+    priv->atom_ok = enif_make_atom(env, "ok");
+    priv->atom_error = enif_make_atom(env, "error");
 
-    return enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_int(env, fd));
+    *priv_data = priv;
+    return 0;
 }
 
 
-static ERL_NIF_TERM read_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+static void i2c_unload(ErlNifEnv *env, void *priv_data)
 {
-    int fd;
-    unsigned int addr;
+    debug("i2c_unload");
+    I2cNifPriv *priv = enif_priv_data(env);
+
+    I2cNifResList *entry = priv->i2c_nif_res_list;
+    I2cNifResList *free_this;
+
+    while(entry != NULL){
+        close(entry->res->fd);
+        enif_release_resource(entry->res);
+        free_this = entry;
+        entry = entry->next;
+        enif_free(free_this);
+    }
+
+    enif_free(priv);
+}
+
+
+static ERL_NIF_TERM i2c_open(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    I2cNifPriv *priv = enif_priv_data(env);
+    
+    char device[16];
+    char devpath[64]="/dev/";
+    unsigned addr;
+
+    if (!enif_get_string(env, argv[0], device, sizeof(device), ERL_NIF_LATIN1))
+        return enif_make_badarg(env);
+    
+    if (!enif_get_uint(env, argv[1], &addr))
+        return enif_make_badarg(env);
+
+    int fd = get_i2c_res_fd(priv->i2c_nif_res_list, device);
+
+    if (fd == 0 ) { // Device has not been opened yet
+        strncat(devpath, device, sizeof(device));
+        fd = open(devpath, O_RDWR);
+        if (fd < 0)
+            return enif_make_tuple2(env, priv->atom_error, 
+                                         enif_make_atom(env, "access_denied"));
+    } 
+
+    I2cNifRes *i2c_nif_res = enif_alloc_resource(priv->i2c_nif_res_type, sizeof(I2cNifRes));
+    strcpy(i2c_nif_res->device, device);
+    i2c_nif_res->fd = fd;
+    i2c_nif_res->addr = addr;
+    add_i2c_nif_res(&priv->i2c_nif_res_list, i2c_nif_res);
+
+    return enif_make_tuple2(env, priv->atom_ok, enif_make_resource(env, i2c_nif_res));
+}
+
+
+static ERL_NIF_TERM i2c_read(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
     unsigned long read_len;
     uint8_t read_data[I2C_BUFFER_MAX];
     ErlNifBinary bin_read;
 
-    if (!enif_get_int(env, argv[0], &fd))
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
+    
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
+
+    if (!enif_get_ulong(env, argv[1], &read_len))
+        return enif_make_badarg(env);
+
+    if (i2c_transfer(res->fd, res->addr, 0, 0, read_data, read_len)) {
+        bin_read.data = read_data;
+        bin_read.size = read_len;
+        return enif_make_binary(env, &bin_read);
+    }
+    else
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "read_failed"));
+}
+
+
+static ERL_NIF_TERM i2c_read_device(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
+    unsigned addr;
+    unsigned long read_len;
+    uint8_t read_data[I2C_BUFFER_MAX];
+    ErlNifBinary bin_read;
+
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
+        return enif_make_badarg(env);
+
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
     if (!enif_get_uint(env, argv[1], &addr))
         return enif_make_badarg(env);
@@ -127,24 +203,51 @@ static ERL_NIF_TERM read_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
     if (!enif_get_ulong(env, argv[2], &read_len))
         return enif_make_badarg(env);
 
-    if (i2c_transfer(fd, addr, 0, 0, read_data, read_len)) {
+    if (i2c_transfer(res->fd, addr, 0, 0, read_data, read_len)) {
         bin_read.data = read_data;
         bin_read.size = read_len;
-        return enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_binary(env, &bin_read));
+        return enif_make_binary(env, &bin_read);
     }
     else
-        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "read_failed"));
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "read_failed"));
 }
 
 
-static ERL_NIF_TERM write_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+static ERL_NIF_TERM i2c_write(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
-    int fd;
-    unsigned int addr;
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
     ErlNifBinary bin_write;
 
-    if (!enif_get_int(env, argv[0], &fd))
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
+        
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
+
+    if (!enif_inspect_binary(env, argv[1], &bin_write))
+        return enif_make_badarg(env);
+
+    if (i2c_transfer(res->fd, res->addr, bin_write.data, bin_write.size, 0, 0)) {
+        return priv->atom_ok;
+    }
+    else
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "write_failed"));
+}
+
+
+static ERL_NIF_TERM i2c_write_device(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
+    unsigned addr;
+    ErlNifBinary bin_write;
+
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
+        return enif_make_badarg(env);
+        
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
     if (!enif_get_uint(env, argv[1], &addr))
         return enif_make_badarg(env);
@@ -152,25 +255,60 @@ static ERL_NIF_TERM write_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
     if (!enif_inspect_binary(env, argv[2], &bin_write))
         return enif_make_badarg(env);
 
-    if (i2c_transfer(fd, addr, bin_write.data, bin_write.size, 0, 0)) {
-        return enif_make_atom(env, "ok");
+    if (i2c_transfer(res->fd, addr, bin_write.data, bin_write.size, 0, 0)) {
+        return priv->atom_ok;
     }
     else
-        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "write_failed"));
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "write_failed"));
 }
 
 
-static ERL_NIF_TERM write_read_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+static ERL_NIF_TERM i2c_write_read(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
-    int fd;
-    unsigned int addr;
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
     ErlNifBinary bin_write;
     uint8_t read_data[I2C_BUFFER_MAX];
     unsigned long read_len;
     ErlNifBinary bin_read;
 
-    if (!enif_get_int(env, argv[0], &fd))
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
+        
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
+
+    if (!enif_inspect_binary(env, argv[1], &bin_write))
+        return enif_make_badarg(env);
+
+    if (!enif_get_ulong(env, argv[2], &read_len))
+        return enif_make_badarg(env);
+
+    if (i2c_transfer(res->fd, res->addr, bin_write.data, bin_write.size, read_data, read_len)) {
+        bin_read.data = read_data;
+        bin_read.size = read_len;
+        return enif_make_binary(env, &bin_read);
+    }
+    else
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "write_read_failed"));
+}
+
+
+static ERL_NIF_TERM i2c_write_read_device(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
+    unsigned addr;
+    ErlNifBinary bin_write;
+    uint8_t read_data[I2C_BUFFER_MAX];
+    unsigned long read_len;
+    ErlNifBinary bin_read;
+
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
+        return enif_make_badarg(env);
+        
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
     if (!enif_get_uint(env, argv[1], &addr))
         return enif_make_badarg(env);
@@ -181,23 +319,45 @@ static ERL_NIF_TERM write_read_i2c(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
     if (!enif_get_ulong(env, argv[3], &read_len))
         return enif_make_badarg(env);
 
-    if (i2c_transfer(fd, addr, bin_write.data, bin_write.size, read_data, read_len)) {
+    if (i2c_transfer(res->fd, addr, bin_write.data, bin_write.size, read_data, read_len)) {
         bin_read.data = read_data;
         bin_read.size = read_len;
-        return enif_make_tuple2(env, enif_make_atom(env, "ok"), enif_make_binary(env, &bin_read));
+        return enif_make_binary(env, &bin_read);
     }
     else
-        return enif_make_tuple2(env, enif_make_atom(env, "error"), enif_make_atom(env, "write_read_failed"));
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "write_read_failed"));
+}
+
+
+static ERL_NIF_TERM i2c_close(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    I2cNifPriv *priv = enif_priv_data(env);
+    I2cNifRes *res;
+
+    if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
+        return enif_make_badarg(env);
+        
+    if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
+        return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
+   
+    del_i2c_nif_res(&priv->i2c_nif_res_list, res); 
+
+    enif_release_resource(res);
+
+    return priv->atom_ok;
 }
 
 
 static ErlNifFunc nif_funcs[] =
 {
-    {"open", 1, open_i2c, ERL_NIF_DIRTY_JOB_IO_BOUND},
-    {"read", 3, read_i2c, 0},
-    {"write", 3, write_i2c, 0},
-    {"write_read", 4, write_read_i2c, 0}
+    {"open", 2, i2c_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"read", 2, i2c_read, 0},
+    {"read_device", 3, i2c_read_device, 0},
+    {"write", 2, i2c_write, 0},
+    {"write_device", 3, i2c_write_device, 0},
+    {"write_read", 3, i2c_write_read, 0},
+    {"write_read_device", 4, i2c_write_read_device, 0},
+    {"close", 1, i2c_close, 0}
 };
 
-
-ERL_NIF_INIT(Elixir.ElixirCircuits.I2C.Nif, nif_funcs, NULL, NULL, NULL, NULL)
+ERL_NIF_INIT(Elixir.ElixirCircuits.I2C.Nif, nif_funcs, i2c_load, NULL, NULL, i2c_unload)

--- a/src/i2c_nif.h
+++ b/src/i2c_nif.h
@@ -1,0 +1,69 @@
+#ifndef I2C_NIF_H
+#define I2C_NIF_H
+
+
+#include "linux/i2c-dev.h"
+#include "erl_nif.h"
+
+#include <err.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define DEBUG
+
+#ifdef DEBUG
+#define log_location stderr
+//#define LOG_PATH "/tmp/elixir_circuits_gpio.log"
+#define debug(...) do { enif_fprintf(log_location, __VA_ARGS__); enif_fprintf(log_location, "\r\n"); fflush(log_location); } while(0)
+#define error(...) do { debug(__VA_ARGS__); } while (0)
+#define start_timing() ErlNifTime __start = enif_monotonic_time(ERL_NIF_USEC)
+#define elapsed_microseconds() (enif_monotonic_time(ERL_NIF_USEC) - __start)
+#else
+#define debug(...)
+#define error(...) do { enif_fprintf(stderr, __VA_ARGS__); enif_fprintf(stderr, "\n"); } while(0)
+#define start_timing()
+#define elapsed_microseconds() 0
+#endif
+
+#define I2C_BUFFER_MAX 8192
+
+// I2C NIF Resource.  Maps device name to file descriptor
+typedef struct{
+    char device[16];
+    int fd;
+    unsigned addr;
+} I2cNifRes;
+
+
+// Linked list of references to I2C NIF Resources
+typedef struct {
+    I2cNifRes *res;
+    void *next;
+} I2cNifResList;
+
+
+// I2C NIF Private data
+typedef struct {
+    ErlNifResourceType *i2c_nif_res_type;
+    I2cNifResList *i2c_nif_res_list;
+    ERL_NIF_TERM atom_ok;
+    ERL_NIF_TERM atom_error;
+} I2cNifPriv;
+
+
+// i2c_nif_res_list.c
+
+void del_i2c_nif_res(I2cNifResList **head, I2cNifRes *del_res);
+void add_i2c_nif_res(I2cNifResList **head, I2cNifRes *add_res);
+int is_i2c_nif_res(I2cNifResList *head, I2cNifRes *chk_res);
+int get_i2c_res_fd(I2cNifResList *head, const char *device);
+
+#endif // I2C_NIF_H

--- a/src/i2c_nif_res_list.c
+++ b/src/i2c_nif_res_list.c
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "i2c_nif.h"
+
+// Handle a linked list of I2C NIF Resources
+
+// Delete the given I2C NIF Resource from the list of resources
+void del_i2c_nif_res(I2cNifResList **head, I2cNifRes *del_res)
+{
+    I2cNifResList *prev_entry = NULL;
+    I2cNifResList *curr_entry = *head;
+
+    while(curr_entry != NULL){
+        if (curr_entry->res == del_res){
+            if (prev_entry == NULL)
+                *head = curr_entry->next;
+            else
+                prev_entry->next = curr_entry->next;
+
+            enif_free(curr_entry);
+            return;
+        }
+        prev_entry = curr_entry;
+        curr_entry = curr_entry->next;
+    }
+}
+
+// Add the given I2C NIF Resource to the list of resources
+void add_i2c_nif_res(I2cNifResList **head, I2cNifRes *add_res)
+{
+    I2cNifResList *new_entry = enif_alloc(sizeof(I2cNifResList));
+    new_entry->res = add_res;
+    new_entry->next = *head;
+    *head = new_entry;
+}
+
+// Check if the given I2C NIF Resource exists in the list of resources
+int is_i2c_nif_res(I2cNifResList *head, I2cNifRes *chk_res)
+{
+    I2cNifResList *curr_entry = head;
+
+    while(curr_entry != NULL){
+        if (curr_entry->res == chk_res)
+            return 1;
+
+        curr_entry = curr_entry->next;
+    }
+    return 0;  // resource is not in list
+}
+
+// Get the fd of the first I2C NIF Resource, that matches the given device name
+// Return zero if no resource has opened the device, yet
+int get_i2c_res_fd(I2cNifResList *head, const char *device)
+{
+    I2cNifResList *curr_entry = head;
+
+    while(curr_entry != NULL){
+        if (strcmp(curr_entry->res->device, device) == 0)
+            return curr_entry->res->fd;
+
+        curr_entry = curr_entry->next;
+    }
+    return 0;  // device not open yet
+}
+
+


### PR DESCRIPTION
Replaced integer file descriptor with references to identify channels when reading and writing data.  Copied the ElixirALE interface.  Default i2c node address is specified on open(), and does not need to be specified on subsequent read(), write(), and write_read() calls.  read_device(), write_device(), and write_read_device() functions are available if other i2c nodes need to be addressed using the same channel reference.
Calling the close() function releases the resources attached to the given reference, but does not close the i2c device file, in case there is more than one process using the i2c bus.
