### PR TITLE
Rename the app from i2c -> elixir_circuits_i2c

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,26 @@
-# I2C - Do not use !!
+# ElixirCircuits.I2C
 
-[![CircleCI](https://circleci.com/gh/ElixirCircuits/i2c.svg?style=svg)](https://circleci.com/gh/ElixirCircuits/i2c)
-[![Hex version](https://img.shields.io/hexpm/v/i2c.svg "Hex version")](https://hex.pm/packages/i2c)
+[![CircleCI](https://circleci.com/gh/elixir-circuits/i2c.svg?style=svg)](https://circleci.com/gh/elixir-circuits/i2c)
+[![Hex version](https://img.shields.io/hexpm/v/elixir_circuits_i2c.svg "Hex version")](https://hex.pm/packages/elixir_circuits_i2c)
 
-`i2c` provides high level abstractions for interfacing to I2C
-buses on Linux platforms. Internally, it uses the Linux
-sysclass interface so that it does not require platform-dependent code.
+`ElixirCircuits.I2C` provides high level abstractions for interfacing to I2C
+buses on Linux platforms. Internally, it uses the [Linux device
+interface](https://elixir.bootlin.com/linux/latest/source/Documentation/i2c/dev-interface)
+so that it does not require board-dependent code.
 
 # Getting started
 
-If you're natively compiling i2c, everything should work like any other
-Elixir library. Normally, you would include elixir_ale as a dependency in your
-`mix.exs` like this:
+If you're using Nerves or compiling on a Raspberry Pi or other device with I2C
+support, then add `elixir_circuits_i2c` like any other Elixir library:
 
 ```elixir
 def deps do
-  [{:i2c, "~> 0.1"}]
+  [{:elixir_circuits_i2c, "~> 0.1"}]
 end
 ```
 
-If you just want to try it out, you can do the following:
-
-```shell
-git clone https://github.com/ElixirCircuits/i2c
-cd i2c
-mix compile
-iex -S mix
-```
-
-If you're cross-compiling, you'll need to setup your environment so that the
-right C compiler is called. See the `Makefile` for the variables that will need
-to be overridden. At a minimum, you will need to set `CROSSCOMPILE`,
-`ERL_CFLAGS`, and `ERL_EI_LIBDIR`.
-
-`i2c` doesn't load device drivers, so you'll need to make sure that any
-necessary ones for accessing I2C are loaded beforehand. On the Raspberry
-Pi, the [Adafruit Raspberry Pi I2C
+`ElixirCircuits.I2C` doesn't load device drivers, so you'll need to load any
+necessary ones beforehand.  On the Raspberry Pi, the [Adafruit Raspberry Pi I2C
 instructions](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-4-gpio-setup/configuring-i2c)
 may be helpful.
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,12 @@ necessary ones beforehand.  On the Raspberry Pi, the [Adafruit Raspberry Pi I2C
 instructions](https://learn.adafruit.com/adafruits-raspberry-pi-lesson-4-gpio-setup/configuring-i2c)
 may be helpful.
 
-If you're trying to compile on a Raspberry Pi and you get errors indicated that Erlang headers are missing
-(`ie.h`), you may need to install erlang with `apt-get install
-erlang-dev` or build Erlang from source per instructions [here](http://elinux.org/Erlang).
-
 # Examples
 
-`i2c` only supports simple uses of the I2C interface in
-Linux, but you can still do quite a bit. The following examples were tested on a
-Raspberry Pi that was connected to an [Erlang Embedded Demo
-Board](http://solderpad.com/omerk/erlhwdemo/). There's nothing special about
-either the demo board or the Raspberry Pi, so these should work similarly on
-other embedded Linux platforms.
+The following examples were tested on a Raspberry Pi that was connected to an
+[Erlang Embedded Demo Board](http://solderpad.com/omerk/erlhwdemo/). There's
+nothing special about either the demo board or the Raspberry Pi, so these should
+work similarly on other embedded Linux platforms.
 
 ## I2C
 
@@ -50,7 +44,7 @@ The protocol for talking to the IO expander is described in the [MCP23008
 Datasheet](http://www.microchip.com/wwwproducts/Devices.aspx?product=MCP23008).
 Here's a simple example of using it.
 
-```Elixir
+```elixir
 # On the Raspberry Pi, the IO expander is connected to I2C bus 1 (i2c-1).
 # Its 7-bit address is 0x20. (see datasheet)
 iex> {:ok, ref} = ElixirCircuits.I2C.open("i2c-1", 0x20)
@@ -88,32 +82,6 @@ iex> ElixirCircuits.I2C.write_read(ref, <<9>>, 1)
 
 ## FAQ
 
-### Where can I get help?
-
-Most issues people have are on how to communicate with hardware for the first
-time. Since `i2c` is a thin wrapper on the Linux sys class interface, you
-may find help by searching for similar issues when using Python or C.
-
-For help specifically with `i2c`, you may also find help on the
-nerves channel on the [elixir-lang Slack](https://elixir-slackin.herokuapp.com/).
-Many [Nerves](http://nerves-project.org) users also use `i2c`.
-
-### Where's PWM support?
-
-On the hardware that I normally use, PWM has been implemented in a
-platform-dependent way. For ease of maintenance, `i2c` doesn't have any
-platform-dependent code, so supporting it would be difficult. An Elixir PWM
-library would be very interesting, though, should anyone want to implement it.
-
-### Can I develop code that uses i2c on my laptop?
-
-You'll need to fake out the hardware. Code to do this depends
-on what your hardware actually does, but here's one example:
-
-  * http://www.cultivatehq.com/posts/compiling-and-testing-elixir-nerves-on-your-host-machine/
-
-Please share other examples if you have them.
-
 ### How do I debug?
 
 The most common issue is communicating with an I2C for the first time.
@@ -144,17 +112,35 @@ still possible that the device will work even if it does not detect, but you
 probably want to check wires at this point. If you have a logic analyzer, use it
 to verify that I2C transactions are being initiated on the bus.
 
+### Where can I get help?
+
+The hardest part is communicating with a device for the first time. The issue is
+usually unrelated to `ElixirCircuits.I2C`. If you expand your searches to
+include Python and C forums, you'll frequently find the answer.
+
+If that fails, try posting a question to the [Elixir
+Forum](https://elixirforum.com/). Tag the question with `Nerves` and it will
+have a good chance of getting to the write people. Feel free to do this even if
+you're not using Nerves.
+
+### Can I develop code that uses ElixirCircuits.I2C on my laptop?
+
+You'll need to fake out the hardware. Code to do this depends
+on what your hardware actually does, but here's one example:
+
+  * http://www.cultivatehq.com/posts/compiling-and-testing-elixir-nerves-on-your-host-machine/
+
+Please share other examples if you have them.
+
 ### Will it run on Arduino?
 
-No. I2c  only runs on Linux-based boards. If you're interested in controlling an Arduino from a computer that can run Elixir, check out [nerves_uart](https://hex.pm/packages/nerves_uart) for communicating via the Arduino's serial connection or [firmata](https://github.com/mobileoverlord/firmata) for communication using the Arduino's Firmata protocol.
-
-### Can I help maintain elixir_circuits?
-
-Yes! If your life has been improved by `i2c` and you want to give back,
-it would be great to have new energy put into this project. Please email me.
+No. This only runs on Linux-based boards. If you're interested in controlling an
+Arduino from a computer that can run Elixir, check out
+[nerves_uart](https://hex.pm/packages/nerves_uart) for communicating via the
+Arduino's serial connection or
+[firmata](https://github.com/mobileoverlord/firmata) for communication using the
+Arduino's Firmata protocol.
 
 # License
 
-This library draws much of its design and code from the Erlang/ALE project which
-is licensed under the Apache License, Version 2.0. As such, it is licensed
-similarly.
+Code from the library is licensed under the Apache License, Version 2.0.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,11 @@
 # Release checklist
 
-  1. Update `CHANGELOG.md` with a bulletpoint list of new features and bug fixes
-  2. Update version numbers in `mix.exs` and `README.md`
-  3. Tag
-  4. Push last commit(s) *and* tags to GitHub
-  5. Wait for the Travis builds to complete successfully
-  6. Copy the latest CHANGELOG.md entry to the GitHub releases description
-  7. Run `mix hex.publish`
-  8. Update version numbers in `CHANGELOG.md` and `mix.exs` for `-dev` work
+1. Update `CHANGELOG.md` with a bulletpoint list of new features and bug fixes
+2. Update version numbers in `mix.exs` and `README.md`
+3. Commit: `git commit -a -m "v0.1.2 release"`
+4. Tag: `git tag -a v0.1.2 -m "v0.1.2 release"`
+5. Push: `git push; git push --tags`
+6. Wait for CircleCI to complete successfully
+7. Copy the latest CHANGELOG.md entry to the GitHub releases description
+8. Publish: `mix hex.publish`
+9. Update version numbers in `CHANGELOG.md` and `mix.exs` for `-dev` work

--- a/lib/i2c/i2c_nif.ex
+++ b/lib/i2c/i2c_nif.ex
@@ -7,7 +7,7 @@ defmodule ElixirCircuits.I2C.Nif do
   """
 
   def load_nif() do
-    nif_binary = Application.app_dir(:i2c, "priv/i2c_nif")
+    nif_binary = Application.app_dir(:elixir_circuits_i2c, "priv/i2c_nif")
 
     case :erlang.load_nif(to_charlist(nif_binary), 0) do
       {:error, reason} ->

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
-defmodule I2C.MixProject do
+defmodule ElixirCircuits.I2C.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :i2c,
+      app: :elixir_circuits_i2c,
       version: "0.1.0",
       elixir: "~> 1.6",
       description: description(),
       package: package(),
-      source_url: "https://github.com/ElixirCircuits/i2c",
+      source_url: "https://github.com/elixir-circuits/i2c",
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
@@ -51,7 +51,7 @@ defmodule I2C.MixProject do
         "Makefile"
       ],
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/ElixirCircuits/i2c"}
+      links: %{"GitHub" => "https://github.com/elixir-circuits/i2c"}
     }
   end
 

--- a/src/i2c_nif.c
+++ b/src/i2c_nif.c
@@ -109,7 +109,7 @@ static void i2c_unload(ErlNifEnv *env, void *priv_data)
     I2cNifResList *entry = priv->i2c_nif_res_list;
     I2cNifResList *free_this;
 
-    while(entry != NULL){
+    while(entry != NULL) {
         close(entry->res->fd);
         enif_release_resource(entry->res);
         free_this = entry;
@@ -124,14 +124,14 @@ static void i2c_unload(ErlNifEnv *env, void *priv_data)
 static ERL_NIF_TERM i2c_open(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     I2cNifPriv *priv = enif_priv_data(env);
-    
+
     char device[16];
     char devpath[64]="/dev/";
     unsigned addr;
 
     if (!enif_get_string(env, argv[0], device, sizeof(device), ERL_NIF_LATIN1))
         return enif_make_badarg(env);
-    
+
     if (!enif_get_uint(env, argv[1], &addr))
         return enif_make_badarg(env);
 
@@ -141,9 +141,9 @@ static ERL_NIF_TERM i2c_open(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
         strncat(devpath, device, sizeof(device));
         fd = open(devpath, O_RDWR);
         if (fd < 0)
-            return enif_make_tuple2(env, priv->atom_error, 
-                                         enif_make_atom(env, "access_denied"));
-    } 
+            return enif_make_tuple2(env, priv->atom_error,
+                                    enif_make_atom(env, "access_denied"));
+    }
 
     I2cNifRes *i2c_nif_res = enif_alloc_resource(priv->i2c_nif_res_type, sizeof(I2cNifRes));
     strcpy(i2c_nif_res->device, device);
@@ -165,7 +165,7 @@ static ERL_NIF_TERM i2c_read(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
 
     if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
-    
+
     if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
         return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
@@ -221,7 +221,7 @@ static ERL_NIF_TERM i2c_write(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 
     if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
-        
+
     if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
         return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
@@ -245,7 +245,7 @@ static ERL_NIF_TERM i2c_write_device(ErlNifEnv *env, int argc, const ERL_NIF_TER
 
     if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
-        
+
     if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
         return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
@@ -274,7 +274,7 @@ static ERL_NIF_TERM i2c_write_read(ErlNifEnv *env, int argc, const ERL_NIF_TERM 
 
     if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
-        
+
     if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
         return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
@@ -306,7 +306,7 @@ static ERL_NIF_TERM i2c_write_read_device(ErlNifEnv *env, int argc, const ERL_NI
 
     if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
-        
+
     if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
         return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
 
@@ -336,11 +336,11 @@ static ERL_NIF_TERM i2c_close(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 
     if (!enif_get_resource(env, argv[0], priv->i2c_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
-        
+
     if (!is_i2c_nif_res(priv->i2c_nif_res_list, res))
         return enif_make_tuple2(env, priv->atom_error, enif_make_atom(env, "invalid_reference"));
-   
-    del_i2c_nif_res(&priv->i2c_nif_res_list, res); 
+
+    del_i2c_nif_res(&priv->i2c_nif_res_list, res);
 
     enif_release_resource(res);
 

--- a/src/i2c_nif_res_list.c
+++ b/src/i2c_nif_res_list.c
@@ -24,8 +24,8 @@ void del_i2c_nif_res(I2cNifResList **head, I2cNifRes *del_res)
     I2cNifResList *prev_entry = NULL;
     I2cNifResList *curr_entry = *head;
 
-    while(curr_entry != NULL){
-        if (curr_entry->res == del_res){
+    while(curr_entry != NULL) {
+        if (curr_entry->res == del_res) {
             if (prev_entry == NULL)
                 *head = curr_entry->next;
             else
@@ -53,7 +53,7 @@ int is_i2c_nif_res(I2cNifResList *head, I2cNifRes *chk_res)
 {
     I2cNifResList *curr_entry = head;
 
-    while(curr_entry != NULL){
+    while(curr_entry != NULL) {
         if (curr_entry->res == chk_res)
             return 1;
 
@@ -68,7 +68,7 @@ int get_i2c_res_fd(I2cNifResList *head, const char *device)
 {
     I2cNifResList *curr_entry = head;
 
-    while(curr_entry != NULL){
+    while(curr_entry != NULL) {
         if (strcmp(curr_entry->res->device, device) == 0)
             return curr_entry->res->fd;
 


### PR DESCRIPTION
While I was renaming, I made a number of minor updates to docs. See the "rename app" commit for the big rename.